### PR TITLE
Add random sorting

### DIFF
--- a/website/app.js
+++ b/website/app.js
@@ -3,6 +3,7 @@ import {
   getLatLongFromGeocache,
   getAddressFromGeocache,
 } from "./utility/geocache.js";
+import sortMerchants from "./utility/sortMerchants.js";
 
 const apiKey = process.env["API_KEY"];
 Airtable.configure({ apiKey: apiKey });
@@ -41,5 +42,7 @@ export async function main(req, res) {
       fetchNextPage();
     });
 
-  res.set("Access-Control-Allow-Origin", "*").send(list);
+  const sortedResults = sortMerchants(list);
+
+  res.set("Access-Control-Allow-Origin", "*").send(sortedResults);
 }

--- a/website/utility/sortMerchants.js
+++ b/website/utility/sortMerchants.js
@@ -1,0 +1,31 @@
+export default function sortMerchants(merchantsArray) {
+  // get zip codes
+  const zipCodes = {};
+
+  for (let merchant of merchantsArray) {
+    const address = merchant["address"];
+    const zipCode = address.split(" ").at(-1);
+
+    if (Object.keys(zipCodes).includes(zipCode)) {
+      zipCodes[zipCode].push(merchant);
+    } else {
+      zipCodes[zipCode] = [merchant];
+    }
+  }
+
+  // TODO: Randomly sort zip codes + merchants. Make 2 arrays of random integers
+  // One will be for the indexes of zip codes. The other will be for merchants.
+
+  // for each zip code, randomly sort restaurants and append to result
+  const result = [];
+
+  for (let zipCode of Object.keys(zipCodes)) {
+    const merchants = zipCodes[zipCode];
+
+    for (let merchant of merchants) {
+      result.push(merchant);
+    }
+  }
+
+  return result;
+}

--- a/website/utility/sortMerchants.js
+++ b/website/utility/sortMerchants.js
@@ -1,3 +1,14 @@
+/**
+ * Sorts a list of merchants by using the zip codes as natural clusters. Algorithm is as follows:
+ * Input is an array of merchants
+ * 1. Group merchants by zip codes
+ * 2. Randomly sort the zip codes (can generate array of random numbers from 1 to number of zip codes)
+ * 3. For each zip code, randomly sort the merchants
+ * 4. Add the merchant.
+ *
+ * @param {*} merchantsArray
+ * @returns array of merchants
+ */
 export default function sortMerchants(merchantsArray) {
   // get zip codes
   const zipCodes = {};

--- a/website/utility/sortMerchants.js
+++ b/website/utility/sortMerchants.js
@@ -1,8 +1,8 @@
 /**
  * Sorts a list of merchants by using the zip codes as natural clusters. Algorithm is as follows:
  * Input is an array of merchants
- * 1. Group merchants by zip codes
- * 2. Randomly sort the zip codes (can generate array of random numbers from 1 to number of zip codes)
+ * 1. Group merchants by zip codes.
+ * 2. Randomly sort the zip codes.
  * 3. For each zip code, randomly sort the merchants
  * 4. Add the merchant.
  *
@@ -10,33 +10,46 @@
  * @returns array of merchants
  */
 export default function sortMerchants(merchantsArray) {
-  // get zip codes
-  const zipCodes = {};
+  const zipcodesToMerchants = {};
 
   for (let merchant of merchantsArray) {
     const address = merchant["address"];
-    const zipCode = address.split(" ").at(-1);
+    const zipcode = address.split(" ").at(-1);
 
-    if (Object.keys(zipCodes).includes(zipCode)) {
-      zipCodes[zipCode].push(merchant);
+    if (Object.keys(zipcodesToMerchants).includes(zipcode)) {
+      zipcodesToMerchants[zipcode].push(merchant);
     } else {
-      zipCodes[zipCode] = [merchant];
+      zipcodesToMerchants[zipcode] = [merchant];
     }
   }
 
-  // TODO: Randomly sort zip codes + merchants. Make 2 arrays of random integers
-  // One will be for the indexes of zip codes. The other will be for merchants.
-
-  // for each zip code, randomly sort restaurants and append to result
   const result = [];
+  const shuffledZipcodes = shuffle(Object.keys(zipcodesToMerchants));
 
-  for (let zipCode of Object.keys(zipCodes)) {
-    const merchants = zipCodes[zipCode];
+  for (let zipcode of shuffledZipcodes) {
+    const shuffledMerchants = shuffle(zipcodesToMerchants[zipcode]);
 
-    for (let merchant of merchants) {
+    for (let merchant of shuffledMerchants) {
       result.push(merchant);
     }
   }
 
   return result;
+}
+
+// https://stackoverflow.com/questions/962802
+function shuffle(array) {
+  var tmp,
+    current,
+    top = array.length;
+
+  if (top)
+    while (--top) {
+      current = Math.floor(Math.random() * (top + 1));
+      tmp = array[current];
+      array[current] = array[top];
+      array[top] = tmp;
+    }
+
+  return array;
 }


### PR DESCRIPTION
Sorts a list of merchants by using the zip codes as natural clusters. Algorithm is as follows:



```
n = number of zip codes
m = number merchants

Input is an array of merchants
1. Group merchants by zip codes. O(n)
2. Randomly sort the zip codes. O(n)
3. For each zip code: O(n)
   * Randomly sort the merchants O(m/n)
   * Add the merchant to result

Time complexity: O(n) + O(n) + [O(n) * O(m/n)] = O(n) + O(m)
```
Would love to hear your thoughts

Potential issues
1. Merchants from zip codes w/ fewer merchants will be over-represented with the current implementation since zipcodes have an equal probability of being selected. Might need to down-weight each zip code by the number of merchants

Other solutions
- Brute force (can find shortest path)= `O(m^2)`. All merchants get equal representation as the first, but merchants in zip codes with more merchants with also float towards the top more.